### PR TITLE
Fix generation with cross-file context

### DIFF
--- a/repo_eval/eval_vllm_repoformer.py
+++ b/repo_eval/eval_vllm_repoformer.py
@@ -85,9 +85,9 @@ def model_inference(args):
             retrieval_prob = torch.softmax(torch.tensor(logits), dim=-1)[49152].item()
             do_retrieval = retrieval_prob > args.retrieval_threshold
             if do_retrieval:
-                cur_pred = llm.generate(entry['llm_prompt_lrcontext'], sampling_params, use_tqdm=False)
-            else:
                 cur_pred = llm.generate(entry['llm_prompt_right_cfc_left'], sampling_params, use_tqdm=False)
+            else:
+                cur_pred = llm.generate(entry['llm_prompt_lrcontext'], sampling_params, use_tqdm=False)
             all_preds.append({
                 "task_id": entry["metadata"]["task_id"],
                 "pred": cur_pred[0].outputs[0].text,


### PR DESCRIPTION
There is a bug in the code generation process when handling cross-file context (CFC). When retrieval of CFC is requested, the model incorrectly generates code snippets using a prompt that excludes CFC. Conversely, when CFC is not requested, the model includes CFC in the prompt.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
